### PR TITLE
Check MIME type of API responses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Imports:
     httr,
     openssl,
     purrr,
-    utils
+    utils,
+    jsonlite
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/edl_search.R
+++ b/R/edl_search.R
@@ -88,7 +88,7 @@ edl_search <- function(short_name = NULL,
   resp <- httr::GET(url,  query = query, netrc_config)
   httr::stop_for_status(resp)
 
-  entry <- httr::content(resp, "parsed")$feed$entry
+  entry <- parse_as_json(resp)$feed$entry
   resp_header <- httr::headers(resp)
   continue <- resp_header[["cmr-search-after"]]
   #i <- 1
@@ -102,7 +102,7 @@ edl_search <- function(short_name = NULL,
                 netrc_config,
                 httr::add_headers("CMR-Search-After" = continue))
 
-      more_entries <- httr::content(resp, "parsed")$feed$entry
+      more_entries <- parse_as_json(resp)$feed$entry
       entry <- c(entry, more_entries)
 
       resp_header <- httr::headers(resp)

--- a/R/edl_set_token.R
+++ b/R/edl_set_token.R
@@ -101,8 +101,8 @@ edl_api <- function(endpoint,
                     ...,
                     httr::add_headers(Authorization= paste("Basic", pw)))
   httr::stop_for_status(resp)
-  p <- httr::content(resp, "parsed", "application/json")
-  p
+
+  parse_as_json(resp)
 }
 
 
@@ -191,4 +191,24 @@ edl_stac_urls <- function(items, assets = "data") {
   purrr::map(items$features, list("assets")) |>
     purrr::map(list(assets)) |>
     purrr::map_chr("href")
+}
+
+parse_as_json <- function(resp, ...) {
+  resp_type <- httr::http_type(resp)
+
+  if (tolower(resp_type) != "application/json") {
+    stop(
+      paste0("The serever returned content of type '", resp_type, "'. Expected a json response"),
+      call. = FALSE
+    )
+  }
+
+  ret <- httr::content(
+    resp,
+    as = "text",
+    type = "application/json",
+    encoding = "UTF-8"
+  )
+
+  jsonlite::fromJSON(ret, ...)
 }

--- a/R/edl_set_token.R
+++ b/R/edl_set_token.R
@@ -184,7 +184,7 @@ edl_revoke_token <- function(
 #' @param items an items list from rstac
 #' @param assets name(s) of assets to extract
 #' @return a vector of hrefs for all discovered assets.
-#' 
+#'
 #' @export
 #'
 edl_stac_urls <- function(items, assets = "data") {
@@ -193,7 +193,7 @@ edl_stac_urls <- function(items, assets = "data") {
     purrr::map_chr("href")
 }
 
-parse_as_json <- function(resp, ...) {
+parse_as_json <- function(resp, simplifyVector = FALSE, ...) {
   resp_type <- httr::http_type(resp)
 
   if (tolower(resp_type) != "application/json") {
@@ -210,5 +210,5 @@ parse_as_json <- function(resp, ...) {
     encoding = "UTF-8"
   )
 
-  jsonlite::fromJSON(ret, ...)
+  jsonlite::fromJSON(ret, simplifyVector = simplifyVector, ...)
 }


### PR DESCRIPTION
More robustly check the responses from the API, throw an informative error if not expected `application/json`, and parse with jsonlite.

Closes #21 