### PR TITLE
parse bounding box vector to character

### DIFF
--- a/R/edl_search.R
+++ b/R/edl_search.R
@@ -79,7 +79,7 @@ edl_search <- function(short_name = NULL,
                 doi = doi,
                 daac = daac,
                 provider = provider,
-                bounding_box = bounding_box,
+                bounding_box = paste(as.character(bounding_box), collapse = ","),
                 page_size = page_size,
                 ...)
   query <- purrr::compact(query)
@@ -151,4 +151,3 @@ edl_extract_urls <- function(items) {
   })
   urls
 }
-

--- a/tests/testthat/test-edl_search.R
+++ b/tests/testthat/test-edl_search.R
@@ -20,3 +20,18 @@ test_that("edl_search", {
   expect_type(href, "character")
 
 })
+
+test_that("edl_search with bounding box", {
+
+  skip_if_offline()
+  skip_on_cran()
+
+  bbox_results <- edl_search(
+    short_name = "ATL08",
+    bounding_box = c(-92.86, 16.26, -91.58, 16.97),
+    parse_results = FALSE
+  )
+
+  expect_s3_class(bbox_results, "cmr_items")
+  expect_gt(length(bbox_results), 1)
+})


### PR DESCRIPTION
Bounding box needs to be collapsed to a single character, similar to temporal. Current failure: 

``` r
library(earthdatalogin)

edl_netrc()

edl_search(
    short_name = "ATL08",
    bounding_box = c(-92.86, 16.26, -91.58, 16.97)
  )
#> Error in `vapply()`:
#> ! values must be length 1,
#>  but FUN(X[[3]]) result is length 4
```

<sup>Created on 2026-02-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>