### PR TITLE
Skip/mock network tests so CRAN checks pass gracefully

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: earthdatalogin
 Title: NASA 'EarthData' Access Utilities
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: 
   c(person(given = "Carl", family = "Boettiger", , "cboettig@gmail.com", c("aut", "cre", "cph"),
          comment = c(ORCID = "0000-0002-1642-628X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# earthdatalogin 0.0.4
+
+* Tests no longer attempt network access on CRAN. The `netcdf access` test now
+  skips on CRAN and when offline, and the `get_nasa_stac_url()` error-path test
+  is mocked so it runs without network access. This resolves the CRAN check
+  ERRORs introduced when the protected NetCDF download ran on CRAN machines.
+
 # earthdatalogin 0.0.3
 
 * Bugfix for edl_s3_token() (#21), which now requires cookies

--- a/tests/testthat/test-edl_netrc.R
+++ b/tests/testthat/test-edl_netrc.R
@@ -18,6 +18,9 @@ test_that("edl_netrc", {
 
 
 test_that("netcdf access", {
+  skip_on_cran()
+  skip_if_offline()
+
   # Since GDAL 2.4 libnetcdf >= 4.5, Mac and Windos lack netcdf vsi support
   # https://gdal.org/en/stable/drivers/raster/netcdf.html#vsi-virtual-file-system-api-support
   url <- "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/AVHRR_OI-NCEI-L4-GLOB-v2.1/20200115120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.1.nc"

--- a/tests/testthat/test-list-nasa-stacs.R
+++ b/tests/testthat/test-list-nasa-stacs.R
@@ -21,5 +21,15 @@ test_that("get_nasa_stac_url() works", {
 })
 
 test_that("get_nasa_stac_url() fails correctly", {
+  # Mock the network call so the error path is tested offline / on CRAN
+  local_mocked_bindings(
+    list_nasa_stacs = function(...) {
+      data.frame(
+        title = "LPCLOUD",
+        href = "https://cmr.earthdata.nasa.gov/cloudstac/LPCLOUD",
+        stringsAsFactors = FALSE
+      )
+    }
+  )
   expect_error(get_nasa_stac_url("notadaac"), "notadaac not found in stacs")
 })


### PR DESCRIPTION
## Problem

CRAN check results for v0.0.3 show ERROR on 9 of 12 flavors (Linux + Windows), all from a failed test:

```
Error: [rast] cannot open this file as a SpatRaster:
/vsicurl/https://archive.podaac.earthdata.nasa.gov/...
```

The failing test is `netcdf access` in `test-edl_netrc.R`. It was added in May 2024 (commit 7ca8547) **without** `skip_on_cran()` / `skip_if_offline()` guards — unlike every other network-dependent test in the suite — so it has always run live on CRAN.

It downloads an EarthData-login-**protected** PODAAC granule, which requires credentials the CRAN machines don't have. The granule has **not** moved: the endpoint still `303`-redirects to a valid presigned URL (`A-userid=None`), so the request simply fails authentication. No docs/examples need updating. The test just can't depend on live, authenticated network access.

## Changes

- Add `skip_on_cran()` + `skip_if_offline()` to the `netcdf access` test, matching the rest of the suite so it fails gracefully when CRAN has no network/credentials.
- Mock `list_nasa_stacs()` in the `get_nasa_stac_url()` error-path test (via `local_mocked_bindings`) so it tests the validation logic with **no** network access at all.
- Bump version to 0.0.4 and add a NEWS entry.

## Verification

Full suite under `load_all()` with no credentials: `FAIL 0 | WARN 0 | SKIP 13 | PASS 2` — the previously-failing test now skips, and the error-path test passes offline via the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)