### PR TITLE
Don't overwrite stored netrc credentials on download (#27, #13)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # earthdatalogin 0.0.4
 
-* `edl_download()` and `edl_netrc()` no longer overwrite stored credentials.
-  Previously, calling `edl_download()` (or a bare `edl_netrc()`) without
-  arguments rewrote the `.netrc` file with the bundled default credentials,
-  clobbering credentials a user had already set and causing 401 errors. Now
-  the netrc is only (re)written when credentials are supplied explicitly or
-  when no earthdata netrc exists yet (#27, #13).
+* `edl_download()`, `edl_search()`, and `edl_netrc()` no longer overwrite
+  stored credentials. Previously, calling these without arguments rewrote the
+  `.netrc` file with the bundled default credentials, clobbering credentials a
+  user had already set and causing 401 errors. Now the netrc is only
+  (re)written when credentials are supplied explicitly or when no earthdata
+  netrc exists yet (#27, #13).
 
 * Tests no longer attempt network access on CRAN. The `netcdf access` test now
   skips on CRAN and when offline, and the `get_nasa_stac_url()` error-path test

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # earthdatalogin 0.0.4
 
+* `edl_download()` and `edl_netrc()` no longer overwrite stored credentials.
+  Previously, calling `edl_download()` (or a bare `edl_netrc()`) without
+  arguments rewrote the `.netrc` file with the bundled default credentials,
+  clobbering credentials a user had already set and causing 401 errors. Now
+  the netrc is only (re)written when credentials are supplied explicitly or
+  when no earthdata netrc exists yet (#27, #13).
+
 * Tests no longer attempt network access on CRAN. The `netcdf access` test now
   skips on CRAN and when offline, and the `get_nasa_stac_url()` error-path test
   is mocked so it runs without network access. This resolves the CRAN check

--- a/R/edl_download.R
+++ b/R/edl_download.R
@@ -36,11 +36,17 @@ edl_download <- function(href,
 
   } else {
 
-    edl_netrc(username = username,
-              password = password,
-              netrc_path = netrc_path,
-              cookie_path = cookie_path,
-              cloud_config = FALSE)
+    # Only (re)write the netrc when the caller explicitly supplies
+    # credentials, or when no earthdata netrc exists yet.  Downloading must
+    # never clobber credentials a user already stored with edl_netrc() (#27).
+    if (!missing(username) || !missing(password) ||
+        !has_edl_netrc(netrc_path)) {
+      edl_netrc(username = username,
+                password = password,
+                netrc_path = netrc_path,
+                cookie_path = cookie_path,
+                cloud_config = FALSE)
+    }
 
 
     if (method == "httr") {

--- a/R/edl_netrc.R
+++ b/R/edl_netrc.R
@@ -40,17 +40,25 @@ edl_netrc <- function(username = default("user"),
   # Bearer auth can conflict
   edl_unset_token()
 
-  # Create a .netrc for earthdatalogin
-  contents <- paste("machine urs.earthdata.nasa.gov login",
-                    username, "password", password)
-  writeLines(contents, netrc_path)
+  # Don't clobber stored credentials.  If the caller did not explicitly
+  # supply a username/password and the netrc file already holds earthdata
+  # credentials, keep them rather than overwriting with the bundled
+  # defaults (#13, #27).
+  if (!missing(username) || !missing(password) ||
+      !has_edl_netrc(netrc_path)) {
+
+    # Create a .netrc for earthdatalogin
+    contents <- paste("machine urs.earthdata.nasa.gov login",
+                      username, "password", password)
+    writeLines(contents, netrc_path)
+
+    # GDAL < 3.7 cannot use an alternative location for .netrc
+    old_gdal_compatibility(netrc_path, contents)
+  }
 
   # set GDAL env vars to use this netrc
   Sys.setenv("GDAL_HTTP_NETRC" = "YES")
   Sys.setenv("GDAL_HTTP_NETRC_FILE" = netrc_path)  # GDAL >= 3.7.0
-
-  # GDAL < 3.7 cannot use an alternative location for .netrc
-  old_gdal_compatibility(netrc_path, contents)
 
   # Set cookie paths as GDAL env vars
   Sys.setenv("GDAL_HTTP_COOKIEFILE" = cookie_path)
@@ -60,6 +68,15 @@ edl_netrc <- function(username = default("user"),
     gdal_cloud_config()
   }
 
+  invisible(TRUE)
+}
+
+#' Does an earthdata .netrc file already exist at this path?
+#' @noRd
+has_edl_netrc <- function(netrc_path = edl_netrc_path()) {
+  file.exists(netrc_path) &&
+    any(grepl("machine urs.earthdata.nasa.gov",
+              readLines(netrc_path, warn = FALSE)))
 }
 
 #' edl_unset_netrc

--- a/R/edl_search.R
+++ b/R/edl_search.R
@@ -62,11 +62,17 @@ edl_search <- function(short_name = NULL,
   #                                       prompt_for_netrc = FALSE)
 
 
-  edl_netrc(username = username,
-            password = password,
-            netrc_path = netrc_path,
-            cookie_path = cookie_path,
-            cloud_config = FALSE)
+  # Only (re)write the netrc when the caller explicitly supplies
+  # credentials, or when no earthdata netrc exists yet, so searching never
+  # clobbers credentials a user already stored with edl_netrc() (#27).
+  if (!missing(username) || !missing(password) ||
+      !has_edl_netrc(netrc_path)) {
+    edl_netrc(username = username,
+              password = password,
+              netrc_path = netrc_path,
+              cookie_path = cookie_path,
+              cloud_config = FALSE)
+  }
   netrc_config <-
     httr::config(netrc = TRUE,
                  netrc_file = netrc_path,

--- a/tests/testthat/test-edl_netrc.R
+++ b/tests/testthat/test-edl_netrc.R
@@ -1,3 +1,37 @@
+test_that("edl_netrc and edl_download do not overwrite stored credentials", {
+  # No network needed: we only check what gets written to the netrc file.
+  netrc <- tempfile()
+  cookie <- tempfile()
+  on.exit(unlink(c(netrc, cookie)), add = TRUE)
+
+  # explicit credentials are written
+  edl_netrc(username = "alice", password = "secret",
+            netrc_path = netrc, cookie_path = cookie, cloud_config = FALSE)
+  expect_match(readLines(netrc), "login alice password secret")
+
+  # a bare call must NOT overwrite the stored credentials with the defaults
+  edl_netrc(netrc_path = netrc, cookie_path = cookie, cloud_config = FALSE)
+  expect_match(readLines(netrc), "login alice password secret")
+
+  # a download without credentials must also leave the netrc intact
+  tryCatch(
+    edl_download("https://urs.earthdata.nasa.gov/nonexistent",
+                 dest = tempfile(), netrc_path = netrc,
+                 cookie_path = cookie, quiet = TRUE),
+    error = function(e) NULL, warning = function(w) NULL
+  )
+  expect_match(readLines(netrc), "login alice password secret")
+
+  # but explicit credentials at download time are honored
+  tryCatch(
+    edl_download("https://urs.earthdata.nasa.gov/nonexistent",
+                 dest = tempfile(), username = "bob", password = "pw2",
+                 netrc_path = netrc, cookie_path = cookie, quiet = TRUE),
+    error = function(e) NULL, warning = function(w) NULL
+  )
+  expect_match(readLines(netrc), "login bob password pw2")
+})
+
 test_that("edl_netrc", {
   skip_on_cran()
   skip_if_offline()


### PR DESCRIPTION
## Problem

`edl_download()` and a bare `edl_netrc()` unconditionally rewrote the `.netrc` file with the bundled **default** credentials (`default("user")`/`default("password")`, which fall back to the public `earthaccess`/`EDL_test1` account when no env vars are set).

This meant the documented workflow silently broke:

```r
edl_netrc(username = "real", password = "real")  # stores real creds
edl_download(href)                                # rewrites netrc with defaults -> 401
```

This is the root cause of #27, and the same overwrite-on-bare-call behavior described in #13.

The reporter in #27 also tried the Bearer-token route as a workaround; it failed for an analogous reason, which contributed to the confusion between the two auth mechanisms (netrc vs. OAuth-style tokens).

## Fix

Only (re)write the netrc when credentials are supplied **explicitly**, or when **no earthdata netrc exists yet** (preserving the zero-config first-run with bundled defaults). Otherwise the existing stored credentials are reused.

- `R/edl_netrc.R` — guard the write with `missing()` + a new `has_edl_netrc()` helper; return `invisible(TRUE)`.
- `R/edl_download.R` — only call `edl_netrc()` when creds are explicit or no netrc exists.
- `tests/testthat/test-edl_netrc.R` — network-free test covering the no-overwrite behavior.
- `NEWS.md` — changelog entry.

## Headless robustness

The decision keys only on `missing()` (a call-frame check) and `file.exists()` — no `interactive()` dependence and no prompts — so it behaves deterministically in `Rscript`/cron/headless sessions.

| Scenario (headless) | Behavior |
|---|---|
| env vars set, no netrc | first download writes netrc from env values, reuses after |
| netrc from prior `edl_netrc("real","pw")` | reused, never overwritten |
| nothing set | falls back to bundled defaults as before |
| explicit creds at download | written/refreshed |

Note (out of scope): the `auth = "token"` path still uses bundled defaults when env vars are absent — it writes no netrc so there's nothing to clobber, but could be made equally explicit in a follow-up.

Closes #27. Addresses #13.
