### PR TITLE
Flatten multi-asset granule URLs; deprecate collections_fetch (#15, #17)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^CRAN-SUBMISSION$
 .Renviron
 [.]code-workspace$
+^\.claude$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 0.0.3
-Date: 2025-07-11 04:00:28 UTC
-SHA: 7d412dc3535c0dff7438b2b0d3eff43f25f03094
+Version: 0.0.4
+Date: 2026-06-12 21:52:32 UTC
+SHA: 800f8eda6877ede185f243f3be6e3dc2a51f2db2

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,13 @@
   (re)written when credentials are supplied explicitly or when no earthdata
   netrc exists yet (#27, #13).
 
+* `edl_extract_urls()` (and `edl_search(parse_results = TRUE)`) now handle
+  granules with multiple data assets, e.g. one GeoTIFF per band. Previously
+  these errored with "Result must be length 1" (#15).
+
+* `collections_fetch()` is deprecated in favor of `rstac::collections_fetch()`,
+  which now provides this functionality upstream (#17).
+
 * Tests no longer attempt network access on CRAN. The `netcdf access` test now
   skips on CRAN and when offline, and the `get_nasa_stac_url()` error-path test
   is mocked so it runs without network access. This resolves the CRAN check

--- a/R/edl_search.R
+++ b/R/edl_search.R
@@ -148,12 +148,14 @@ print.cmr_items <- function(x, ...) {
 #'
 edl_extract_urls <- function(items) {
   all_links <- purrr::map(items, "links")
-  urls <- purrr::map_chr(all_links, function(links) {
+  # A granule may carry multiple data assets (e.g. one tif per band), so map
+  # over granules and flatten -- map_chr would error on the >1 case (#15).
+  urls <- purrr::map(all_links, function(links) {
     is_data <-
       grepl("Download", purrr::map_chr(links, "title", .default="")) &
       grepl("\\/data#", purrr::map_chr(links, "rel", .default=""))
 
     purrr::map_chr(links[is_data], "href")
   })
-  urls
+  unlist(urls, use.names = FALSE)
 }

--- a/R/stac-collections_fetch.R
+++ b/R/stac-collections_fetch.R
@@ -10,17 +10,25 @@
 #' 
 #' @return A `doc_collections` object with all of the collections from the catalogue
 #'   specified in the [rstac::collections()] query.
-#' 
+#'
+#' @details **Deprecated**: this functionality is now available upstream as
+#'   [rstac::collections_fetch()]; please use that instead.
+#'
 #' @examplesIf interactive()
-#' 
-#'  rstac::stac("https://cmr.earthdata.nasa.gov/stac/LPCLOUD") |> 
-#'    rstac::collections() |> 
-#'    rstac::get_request() |> 
+#'
+#'  rstac::stac("https://cmr.earthdata.nasa.gov/stac/LPCLOUD") |>
+#'    rstac::collections() |>
+#'    rstac::get_request() |>
 #'    collections_fetch()
-#' 
+#'
 #' @export
 collections_fetch <- function(collections, ...) {
-  
+
+  .Deprecated("rstac::collections_fetch",
+              msg = paste0("`earthdatalogin::collections_fetch()` is ",
+                           "deprecated; use `rstac::collections_fetch()` ",
+                           "instead."))
+
   if (!inherits(collections, "doc_collections")) {
     stop("'collections' must be a `doc_collections` object from the `rstac` package", 
     call. = FALSE)

--- a/man/collections_fetch.Rd
+++ b/man/collections_fetch.Rd
@@ -21,6 +21,10 @@ By default, NASA STAC catalogue collections queries only return
 10 collections at a time. This function will page through
 the collections and return them all.
 }
+\details{
+\strong{Deprecated}: this functionality is now available upstream as
+\code{\link[rstac:collections_fetch]{rstac::collections_fetch()}}; please use that instead.
+}
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 

--- a/tests/testthat/test-edl_search.R
+++ b/tests/testthat/test-edl_search.R
@@ -35,3 +35,25 @@ test_that("edl_search with bounding box", {
   expect_s3_class(bbox_results, "cmr_items")
   expect_gt(length(bbox_results), 1)
 })
+
+test_that("edl_extract_urls flattens multi-asset granules (#15)", {
+  # No network: a granule with several data links (e.g. one tif per band)
+  # must not error and should return all data URLs.
+  data_link <- function(href) {
+    list(rel = "http://esipfed.org/ns/fedsearch/1.1/data#",
+         title = "Download file", href = href)
+  }
+  items <- list(
+    list(links = list(data_link("https://example.org/a_B01.tif"),
+                      data_link("https://example.org/a_B02.tif"),
+                      list(rel = "self", title = "metadata",
+                           href = "https://example.org/a.xml"))),
+    list(links = list(data_link("https://example.org/b_B01.tif")))
+  )
+
+  urls <- edl_extract_urls(items)
+  expect_type(urls, "character")
+  expect_equal(urls, c("https://example.org/a_B01.tif",
+                       "https://example.org/a_B02.tif",
+                       "https://example.org/b_B01.tif"))
+})


### PR DESCRIPTION
## #15 — `edl_search()` error on multi-asset granules

`edl_extract_urls()` used an outer `purrr::map_chr()`, which requires exactly one URL per granule. Granules with multiple data assets (e.g. HLSL30 returns ~15 band GeoTIFFs) made the inner `map_chr` return a length-15 vector, triggering:

```
Error in `purrr::map_chr()`: Result must be length 1, not 15.
```

Fix: map over granules with `purrr::map()` and `unlist(use.names = FALSE)` to return a flat character vector of all data URLs — matching the documented `@return`. Added a network-free regression test.

## #17 — deprecate `collections_fetch()`

This functionality now ships upstream in `rstac` (installed `rstac` 1.0.1 exports `collections_fetch()`). Added a `.Deprecated("rstac::collections_fetch")` call and a note in the docs. Kept the implementation in place for one cycle for back-compat.

Closes #15. Closes #17.